### PR TITLE
Fix bug with Inconsistents time unit conversion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.rnorth.visible-assertions</groupId>
             <artifactId>visible-assertions</artifactId>
-            <version>1.0.3</version>
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/rnorth/ducttape/inconsistents/Inconsistents.java
+++ b/src/main/java/org/rnorth/ducttape/inconsistents/Inconsistents.java
@@ -38,7 +38,7 @@ public class Inconsistents {
         long[] bestRun = {0};
         Object[] bestRunValue = {null};
 
-        long consistentTimeInMillis = timeUnit.convert(consistentTime, TimeUnit.MILLISECONDS);
+        long consistentTimeInMillis = TimeUnit.MILLISECONDS.convert(consistentTime, timeUnit);
 
         return Unreliables.retryUntilSuccess(totalTimeout, timeUnit, () -> {
             T value = lambda.call();

--- a/src/test/java/org/rnorth/ducttape/inconsistents/InconsistentsTest.java
+++ b/src/test/java/org/rnorth/ducttape/inconsistents/InconsistentsTest.java
@@ -5,6 +5,7 @@ import org.rnorth.ducttape.TimeoutException;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertTrue;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 
 
@@ -48,5 +49,19 @@ public class InconsistentsTest {
             Throwable cause = e.getCause();
             assertEquals("An exception is thrown if the result is never consistent", InconsistentResultsException.class, cause.getClass());
         }
+    }
+
+    @Test
+    public void testUnitConversion() {
+        long start = System.currentTimeMillis();
+
+        Inconsistents.retryUntilConsistent(1, 5, TimeUnit.SECONDS, () -> {
+            Thread.sleep(10L);
+            // this result won't be consistent until after 1.5s
+            long now = System.currentTimeMillis();
+            return (now - start) / 1500;
+        });
+
+        assertTrue("At least one second elapsed", System.currentTimeMillis() - start > 1000);
     }
 }


### PR DESCRIPTION
Fix a bug whereby inconsistents utility would incorrectly convert any interval expressed in a non-milliseconds unit.