### PR TITLE
Unreliables, custom exception handling

### DIFF
--- a/src/main/java/org/rnorth/ducttape/ExecutionException.java
+++ b/src/main/java/org/rnorth/ducttape/ExecutionException.java
@@ -1,0 +1,7 @@
+package org.rnorth.ducttape;
+
+public class ExecutionException extends RuntimeException {
+    public ExecutionException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/rnorth/ducttape/timeouts/Timeouts.java
+++ b/src/main/java/org/rnorth/ducttape/timeouts/Timeouts.java
@@ -65,7 +65,7 @@ public class Timeouts {
             return future.get(timeout, timeUnit);
         } catch (ExecutionException e) {
             // The cause of the ExecutionException is the actual exception that was thrown
-            throw new RuntimeException(e.getCause());
+            throw new org.rnorth.ducttape.ExecutionException(e.getCause());
         } catch (TimeoutException | InterruptedException e) {
             throw new org.rnorth.ducttape.TimeoutException(e);
         }

--- a/src/test/java/org/rnorth/ducttape/unreliables/UnreliablesTest.java
+++ b/src/test/java/org/rnorth/ducttape/unreliables/UnreliablesTest.java
@@ -1,5 +1,6 @@
 package org.rnorth.ducttape.unreliables;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.rnorth.ducttape.RetryCountExceededException;
 import org.rnorth.ducttape.TimeoutException;
@@ -37,13 +38,19 @@ public class UnreliablesTest {
                 return false;
             }, IllegalStateException.class);
         } catch (Exception e) {
-            while (e.getCause() != null || !e.getClass().equals(IllegalStateException.class)) {
-                e = (Exception) e.getCause();
-            }
+            e = getRootCause(e);
             if (!e.getClass().equals(IllegalStateException.class)) {
                 fail("When an exception is thrown excution should not be proceeded with");
             }
         }
+    }
+
+    @NotNull
+    private Exception getRootCause(Exception e) {
+        while (e.getCause() != null || !e.getClass().equals(IllegalStateException.class)) {
+            e = (Exception) e.getCause();
+        }
+        return e;
     }
 
     @Test

--- a/src/test/java/org/rnorth/ducttape/unreliables/UnreliablesTest.java
+++ b/src/test/java/org/rnorth/ducttape/unreliables/UnreliablesTest.java
@@ -40,7 +40,7 @@ public class UnreliablesTest {
         } catch (Exception e) {
             e = getRootCause(e);
             if (!e.getClass().equals(IllegalStateException.class)) {
-                fail("When an exception is thrown excution should not be proceeded with");
+                fail("When an exception is thrown execution should not be proceeded with");
             }
         }
     }

--- a/src/test/java/org/rnorth/ducttape/unreliables/UnreliablesTest.java
+++ b/src/test/java/org/rnorth/ducttape/unreliables/UnreliablesTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.rnorth.ducttape.RetryCountExceededException;
 import org.rnorth.ducttape.TimeoutException;
 
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -23,6 +24,25 @@ public class UnreliablesTest {
             Unreliables.retryUntilTrue(500, TimeUnit.MILLISECONDS, () -> true);
         } catch (TimeoutException e) {
             fail("When retrying until true, an immediate return true should be OK but timed out");
+        }
+    }
+
+    @Test
+    public void testRetryUntilAnExceptionIsThrown() throws Exception {
+        try {
+            Unreliables.retryUntilTrue(5000, TimeUnit.MILLISECONDS, () -> {
+                if (new Random().nextInt(2) == 1) {
+                    throw new IllegalStateException();
+                }
+                return false;
+            }, IllegalStateException.class);
+        } catch (Exception e) {
+            while (e.getCause() != null || !e.getClass().equals(IllegalStateException.class)) {
+                e = (Exception) e.getCause();
+            }
+            if (!e.getClass().equals(IllegalStateException.class)) {
+                fail("When an exception is thrown excution should not be proceeded with");
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/rnorth/duct-tape/issues/11

Adds a varargs list of exception classes to all `Unreliables` methods upon which `Unreliables` should not make further retries and stop execution immediately.

For example that could make fixing https://github.com/testcontainers/testcontainers-java/issues/3317 much easier.